### PR TITLE
Fix new tab issue when shortcuts and recent activity are disabled

### DIFF
--- a/chrome/ShyFox/content/shy-new-tab.css
+++ b/chrome/ShyFox/content/shy-new-tab.css
@@ -131,6 +131,10 @@ Styles for new tab
     background-color: var(--tr-col);
     border-radius: var(--giant-rounding);
   }
+
+  .only-search .search-wrapper {
+    padding-top: 34px !important;
+  }
   
   /* settings */
   .icon-settings:hover {background-color: var(--tr-hov-col) !important;}


### PR DESCRIPTION
I found that when both shortcuts and recent activity are disabled on the new tab page, the padding on the blurred element was off:

![Screenshot from 2024-07-18 14-52-23](https://github.com/user-attachments/assets/e18dbe45-9176-4a73-8e5e-14894302f234)

I've fixed that in this patch:

![Screenshot from 2024-07-18 14-52-44](https://github.com/user-attachments/assets/301a857c-304e-4e7a-b7dc-887dfd9929df)
 