### PR TITLE
feat(sidebar): Collapse after delay

### DIFF
--- a/chrome/ShyFox/shy-sidebar.css
+++ b/chrome/ShyFox/shy-sidebar.css
@@ -135,6 +135,26 @@ Styles for sidebar
     ) !important;
 
     border-radius: var(--big-rounding) !important;
+    border: var(--outline) !important;
+    outline: var(--shadow) !important;
+    background-color: var(--bg-col) !important;
+
+    /* dont delay sidebar movement and transform on toggle */
+    /* delay sidebar, border and indication bar disappearance */
+    &:not(:hover) {
+      transition:
+          var(--transition) var(--trans-delay),
+            top var(--trans-dur) ease-out 0s,
+            height var(--trans-dur) ease-out 0s,
+            background-color 0s ease-out 0s,
+            border-radius var(--trans-dur) ease-out 0s !important;
+      border-color: transparent !important;
+      outline-color: transparent !important;
+      
+      &::after {
+        transition-delay: var(--trans-delay);
+      }
+    }
     
     /* hover target (invisible box between window edge and panel) */
     &::before{
@@ -153,6 +173,12 @@ Styles for sidebar
     & > * {
       transition: var(--transition) !important;
       opacity: 0;
+      /* delay panel content disappearance */
+      &:not(:hover) {
+        transition:
+          var(--transition) var(--trans-delay), border-radius var(--trans-dur) ease-out 0s !important;
+        border-radius: var(--big-rounding) !important;
+      }
     }
   }
   
@@ -202,7 +228,10 @@ Styles for sidebar
   }
   
   /* add rounded corners to sidebar content */
-  #sidebar {border-radius: var(--big-rounding) !important;}
+  #sidebar {
+    border-radius: var(--big-rounding) !important;
+    transition-delay: 0s !important;
+  }
   
   /* styles for bookmarks */
   #PersonalToolbar{
@@ -251,7 +280,10 @@ Styles for sidebar
             
       &::after{opacity: 0}
       
-      & > * {opacity: var(--dyn-opct);}
+      & > * {
+        opacity: var(--dyn-opct);
+        transition-delay: 0s !important; /* prevent opacity delay on sidebar contents */
+      }
     }
   }
 }

--- a/chrome/ShyFox/shy-variables.css
+++ b/chrome/ShyFox/shy-variables.css
@@ -24,6 +24,7 @@ Values of these variables can be changed safely and most likely nothing will bre
   
   /* animations time */
   --trans-dur: 0.25s;
+  --trans-delay: 1s;
   
   /* width of some elements. 1vw is one hundredth of the screen width */
   --sdbr-wdt: 300px;


### PR DESCRIPTION
# Closes #97
- feat(sidebar): add delay before collapsing
- fix(sidebar): delayed color change on new tab when collapsed
- fix(sidebar): delayed various transformations when toggling `Hide sidebar` through UCToggle 

## Added variables
`--trans-delay: 1s`

## Known issues when toggling "Hide sidebar":
- indication bar visible
  - tried multiple css hacks to no avail, could be fixed by momentarily toggling `:hover` on `#sidebar` through UCToggle 
- Sidebar cannot transform `left`
  - same possible fix as the indication bar, or a more complicated `animation` property

## Video
Shows feature and the known issues

https://github.com/user-attachments/assets/0f2149cc-a6e9-4395-bbcc-4fea8c6a5c5d

