### PR TITLE
feat(icons): add default monochrome filter

### DIFF
--- a/chrome/ShyFox/shy-icons.css
+++ b/chrome/ShyFox/shy-icons.css
@@ -35,10 +35,16 @@ Monochrome icons for some extensions
 
 @media (-moz-bool-pref: "shyfox.enable.ext.mono.toolbar.icons") {
 
+  /* Default monochrome effect for all other icons */
+  :is(.webextension-browser-action, .eom-addon-button) .toolbarbutton-icon {
+    filter: grayscale(100%) brightness(175%);
+  }
+
   /* Userchrome Toggle => sidebar icon */
   :is(.webextension-browser-action,
   .eom-addon-button):is([data-extensionid="userchrome-toggle-extended@n2ezr.ru"]) 
   .toolbarbutton-icon {
+    filter: none;
     list-style-image: url("../icons/command-frames.svg");
   }
 
@@ -46,6 +52,7 @@ Monochrome icons for some extensions
   :is(.webextension-browser-action,
   .eom-addon-button)[data-extensionid="uBlock0@raymondhill.net"] 
   .toolbarbutton-icon {
+    filter: none;
     list-style-image: url("../icons/ublock.svg");
   }
 
@@ -53,6 +60,7 @@ Monochrome icons for some extensions
   :is(.webextension-browser-action,
   .eom-addon-button)[data-extensionid="{446900e4-71c2-419f-a6a7-df9c091e268b}"] 
   .toolbarbutton-icon {
+    filter: none;
     list-style-image: url("../icons/bitwarden.svg");
   }
 
@@ -60,6 +68,7 @@ Monochrome icons for some extensions
   :is(.webextension-browser-action,
   .eom-addon-button)[data-extensionid="jid1-MnnxcxisBPnSXQ@jetpack"] 
   .toolbarbutton-icon {
+    filter: none;
     list-style-image: url("../icons/PrivacyBadger.svg");
     scale: 1.3;
   }
@@ -68,6 +77,7 @@ Monochrome icons for some extensions
   :is(.webextension-browser-action,
   .eom-addon-button)[data-extensionid="addon@darkreader.org"] 
   .toolbarbutton-icon {
+    filter: none;
     list-style-image: url("../icons/moon.svg");
   }
 


### PR DESCRIPTION
- feat(icons): add default monochrome filter
  - Applies a close enough monochrome filter to extension icons
  - Excludes extensions with custom svg icons
## Screenshot
![image](https://github.com/user-attachments/assets/4284da7f-479d-4c36-9e90-a17303e3d418)
