### PR TITLE
Fix background clipping after latest Firefox update

### DIFF
--- a/chrome/ShyFox/shy-floating-search.css
+++ b/chrome/ShyFox/shy-floating-search.css
@@ -39,11 +39,11 @@ Cool floating search panel
       pointer-events: none;
       border-radius: var(--rounding);
 
-      width: 100vw;
-      height: 100vh;
+      width: 200vw;
+      height: 200vh;
 
-      top: 0px;
-      left: 0px;
+      top: -30vh;
+      left: -30vw;
 
       background-color: color-mix(in srgb, var(--bg-col) 80%, transparent);
     }


### PR DESCRIPTION
After latest Firefox update, the transparent background from the floating search bar doesn't follow the global size of the opened window.

I'm not a web developer whatsoever, so if anyone reading this has a cleaner solution for this bug, please answer to the PR.

