### PR TITLE
Fix toolbar visibility after Firefox v137 update

### DIFF
--- a/chrome/ShyFox/shy-findbar.css
+++ b/chrome/ShyFox/shy-findbar.css
@@ -13,14 +13,8 @@ findbar{
   z-index: 5 !important;
   
   bottom: calc(var(--bottom-margin) + var(--margin));
-  left: calc(
-    (
-      100vw
-      - var(--findbar-wdt)
-      - var(--left-margin)
-      - var(--right-margin)
-    ) / 2
-  );
+  left: 50% !important;
+  transform: translateX(-50%) !important;
   
   height: calc(var(--toolbar-item-hgt) * 2);
   padding-top: var(--toolbar-item-hgt) !important;

--- a/chrome/ShyFox/shy-global.css
+++ b/chrome/ShyFox/shy-global.css
@@ -548,8 +548,8 @@ File Edit View History Bookmarks Tools Help
 /* remove annoying line at the top of the window */
 #navigator-toolbox {
   margin-top: -1px !important;
-  position: relative;
-  z-index: 3;
+  position: relative !important;
+  z-index: 3 !important;
 }
 
 /* weird margin fix */


### PR DESCRIPTION
Fixes #242 

This simple fix forces the z-index set in `shy-global.css` to override the value set by Firefox in version 137.